### PR TITLE
Fixes Feeding

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -85,7 +85,7 @@
 					user.visible_message("<span class='danger'>[user] cannot force anymore of [src] down [M]'s throat.</span>")
 					return 0
 
-				if(!do_mob(user, M,10)) return
+				if(!do_mob(user, M,30)) return // 30 tick (3 second) delay to force-feeding
 
 				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been fed [src.name] by [user.name] ([user.ckey]) Reagents: [reagentlist(src)]</font>")
 				user.attack_log += text("\[[time_stamp()]\] <font color='red'>Fed [src.name] by [M.name] ([M.ckey]) Reagents: [reagentlist(src)]</font>")

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -59,6 +59,13 @@
 	return res
 
 /datum/disease2/disease/proc/activate(var/mob/living/carbon/mob)
+
+	/*if (ishuman(mob))
+		var/mob/living/carbon/human/H = mob
+		if(H.species.flags & IS_SYNTHETIC)   //TEMP FIX UNTIL IPC BUG CONFIRMED
+			cure(mob)
+			return
+	*/
 	if(dead)
 		cure(mob)
 		return


### PR DESCRIPTION
Increases time on force-feeding to 3 seconds, that of a syringe; also
introduced a (commented out) fix for IPCs getting viruses, as they
literally shouldn't be able to. Until we see it happen live, the bug
will have to remain.
