### PR TITLE
Added Cordrazine and Pyroxadone

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -793,7 +793,8 @@
 					/obj/item/weapon/reagent_containers/glass/bottle/stoxin = 4,/obj/item/weapon/reagent_containers/glass/bottle/toxin = 4,
 					/obj/item/weapon/reagent_containers/syringe/antiviral = 4,/obj/item/weapon/reagent_containers/syringe = 12,
 					/obj/item/device/healthanalyzer = 5,/obj/item/weapon/reagent_containers/glass/beaker = 4, /obj/item/weapon/reagent_containers/dropper = 2,
-					/obj/item/stack/medical/advanced/bruise_pack = 3, /obj/item/stack/medical/advanced/ointment = 3, /obj/item/stack/medical/splint = 2)
+					/obj/item/stack/medical/advanced/bruise_pack = 3, /obj/item/stack/medical/advanced/ointment = 3, /obj/item/stack/medical/splint = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine = 3)
 	contraband = list(/obj/item/weapon/reagent_containers/pill/tox = 3,/obj/item/weapon/reagent_containers/pill/stox = 4,/obj/item/weapon/reagent_containers/pill/antitox = 6)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 
@@ -814,7 +815,7 @@
 	icon_deny = "wallmed-deny"
 	req_access = list(access_medical)
 	density = 0 //It is wall-mounted, and thus, not dense. --Superxpdude
-	products = list(/obj/item/stack/medical/bruise_pack = 2,/obj/item/stack/medical/ointment = 2,/obj/item/weapon/reagent_containers/hypospray/autoinjector = 4,/obj/item/device/healthanalyzer = 1)
+	products = list(/obj/item/stack/medical/bruise_pack = 2,/obj/item/stack/medical/ointment = 2,/obj/item/weapon/reagent_containers/hypospray/autoinjector = 4,/obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine = 2,/obj/item/device/healthanalyzer = 1)
 	contraband = list(/obj/item/weapon/reagent_containers/syringe/antitoxin = 4,/obj/item/weapon/reagent_containers/syringe/antiviral = 4,/obj/item/weapon/reagent_containers/pill/tox = 1)
 
 /obj/machinery/vending/wallmed2

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -40,13 +40,16 @@
 
 	New()
 		..()
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
-		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine(src) //only two since it's so easy to get more
-		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine(src)
 		return
+		
 
 
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -44,9 +44,8 @@
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
-		new /obj/item/weapon/tank/anesthetic(src)
-		new /obj/item/weapon/tank/anesthetic(src)
-		new /obj/item/clothing/mask/breath/medical(src)
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine(src) //only two since it's so easy to get more
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine(src)
 		return
 
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -40,11 +40,11 @@
 
 	New()
 		..()
+		new /obj/item/weapon/tank/oxygen(src)
+		new /obj/item/clothing/mask/breath/medical(src)
 		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine
 		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine
 		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine
-		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine
-		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)
 		new /obj/item/weapon/reagent_containers/syringe/melorazine(src)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -206,14 +206,14 @@
 /datum/reagent/pyroxadone
 	name = "Pyroxadone"
 	id = "pyroxadone"
-	description = "A powerful chemical substance that rapidly heals and the body, while at very high temperatures. Don't mix this up with Cryoxadone!"
+	description = "A powerful chemical substance that rapidly heals the body, while at very high temperatures. Perfect for fire-related patients."
 	reagent_state = LIQUID
 	color = "#8080FF"
 	metabolism = REM * 0.5
 	scannable = 1
 
 /datum/reagent/pyroxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.bodytemperature > 420)
+	if(M.bodytemperature > 400)
 		M.adjustCloneLoss(-10 * removed)
 		M.adjustOxyLoss(-20 * removed)
 		M.heal_organ_damage(20 * removed, 20 * removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -7,7 +7,7 @@
 	reagent_state = LIQUID
 	color = "#8A0808"
 	overdose = REAGENTS_OVERDOSE
-	metabolism = REM * 5
+	metabolism = REM * 3
 	scannable = 1
 
 /datum/reagent/cordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -16,7 +16,7 @@
 		M.AdjustWeakened(-2)
 		M.AdjustStunned(-2)
 		M.drowsyness = max(M.drowsyness - 10, 0)
-		if(prob(50))
+		if(prob(50)) //Has a 50% chance of healing a minor heart attack, then another 50% chance of healing cardiac arrest
 			M.heart_attack = 0
 			if (prob(50))
 				M.cardiac_arrest = 0
@@ -40,7 +40,7 @@
 		M.add_chemical_effect(CE_PAINKILLER, 50)
 		M.AdjustParalysis(-1)
 		M.AdjustWeakened(-1)
-		M.adjustToxLoss(removed * 5)
+		M.adjustToxLoss(removed * 5) //all of this wonder needs a tradeoff, right?
 		M.adjustOxyLoss(-40 * removed)
 		M.heart_attack = 0
 		M.cardiac_arrest = 0

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -21,6 +21,8 @@
 			if (prob(50))
 				M.cardiac_arrest = 0
 		
+		holder.remove_reagent("melorazine", 2 * removed) //to make it better at countering Melorazine
+		holder.remove_reagent("stoxin", 2 * removed)
 
 /datum/reagent/chloromydride
 	name = "Chloromydride"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -213,7 +213,7 @@
 	scannable = 1
 
 /datum/reagent/pyroxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.bodytemperature > 400)
+	if(M.bodytemperature > 420)
 		M.adjustCloneLoss(-10 * removed)
 		M.adjustOxyLoss(-20 * removed)
 		M.heal_organ_damage(20 * removed, 20 * removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -7,7 +7,7 @@
 	reagent_state = LIQUID
 	color = "#8A0808"
 	overdose = REAGENTS_OVERDOSE
-	metabolism = REM * 3
+	metabolism = REM * 5
 	scannable = 1
 
 /datum/reagent/cordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -40,7 +40,7 @@
 		M.add_chemical_effect(CE_PAINKILLER, 50)
 		M.AdjustParalysis(-1)
 		M.AdjustWeakened(-1)
-		M.adjustToxLoss(removed * 5) //all of this wonder needs a tradeoff, right?
+		M.adjustToxLoss(removed * 6) //all of this wonder needs a tradeoff, right?
 		M.adjustOxyLoss(-40 * removed)
 		M.heart_attack = 0
 		M.cardiac_arrest = 0

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -206,18 +206,18 @@
 /datum/reagent/pyroxadone
 	name = "Pyroxadone"
 	id = "pyroxadone"
-	description = "A powerful chemical substance that rapidly heals the body, while at very high temperatures. Perfect for fire-related patients."
+	description = "A powerful chemical substance that rapidly heals the body, while at very high temperatures. Rise from the flames, stronger than before.."
 	reagent_state = LIQUID
 	color = "#8080FF"
 	metabolism = REM * 0.5
 	scannable = 1
 
 /datum/reagent/pyroxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.bodytemperature > 420)
+	if(M.bodytemperature > 420) //The body starts taking damage from fever and such at 360. This should ensure that they only get the healing if they're actually on fire or were in a very hot environment.
 		M.adjustCloneLoss(-10 * removed)
 		M.adjustOxyLoss(-20 * removed)
-		M.heal_organ_damage(20 * removed, 20 * removed)
-		M.adjustToxLoss(-10 * removed)
+		M.heal_organ_damage(30 * removed, 30 * removed)
+		M.adjustToxLoss(-20 * removed)
 
 /datum/reagent/clonexadone
 	name = "Clonexadone"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1,8 +1,31 @@
+//TODO: Stenophyl
+
+/datum/reagent/cordrazine
+	name = "Cordrazine"
+	id = "cordrazine"
+	description = "Cordrazine is a fast-acting cardiac and synaptic stimulant, useful for waking up comatose patients, and combating minor cardiac conditions."
+	reagent_state = LIQUID
+	color = "#8A0808"
+	overdose = REAGENTS_OVERDOSE
+	metabolism = REM * 3
+	scannable = 1
+
+/datum/reagent/cordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien != IS_DIONA)
+		M.AdjustParalysis(-2)
+		M.AdjustWeakened(-2)
+		M.AdjustStunned(-2)
+		M.drowsyness = max(M.drowsyness - 10, 0)
+		if(prob(50))
+			M.heart_attack = 0
+			if (prob(50))
+				M.cardiac_arrest = 0
+		
 
 /datum/reagent/chloromydride
 	name = "Chloromydride"
 	id = "chloromydride"
-	description = "Chloromydride is a strong cardiac stimulant, usually used for cardiac arrest. Be warned, however - It has dangerous side effects."
+	description = "Chloromydride is an incredibly strong cardiac stimulant, usually used for cardiac arrest. Be warned, however - It has dangerous side effects."
 	reagent_state = LIQUID
 	color = "#F600FA"
 	overdose = 15
@@ -12,12 +35,13 @@
 /datum/reagent/chloromydride/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_STABLE)
-		M.add_chemical_effect(CE_PAINKILLER, 40)
+		M.add_chemical_effect(CE_PAINKILLER, 50)
 		M.AdjustParalysis(-1)
 		M.AdjustWeakened(-1)
-		M.AdjustStunned(-1)
 		M.adjustToxLoss(removed * 5)
-		M.adjustOxyLoss(-30 * removed)
+		M.adjustOxyLoss(-40 * removed)
+		M.heart_attack = 0
+		M.cardiac_arrest = 0
 
 
 /datum/reagent/inaprovaline
@@ -34,7 +58,6 @@
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_STABLE)
 		M.add_chemical_effect(CE_PAINKILLER, 25)
-
 
 /datum/reagent/bicaridine
 	name = "Bicaridine"
@@ -178,6 +201,22 @@
 		M.adjustCloneLoss(-10 * removed)
 		M.adjustOxyLoss(-10 * removed)
 		M.heal_organ_damage(10 * removed, 10 * removed)
+		M.adjustToxLoss(-10 * removed)
+		
+/datum/reagent/pyroxadone
+	name = "Pyroxadone"
+	id = "pyroxadone"
+	description = "A powerful chemical substance that rapidly heals and the body, while at very high temperatures. Don't mix this up with Cryoxadone!"
+	reagent_state = LIQUID
+	color = "#8080FF"
+	metabolism = REM * 0.5
+	scannable = 1
+
+/datum/reagent/pyroxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(M.bodytemperature > 420)
+		M.adjustCloneLoss(-10 * removed)
+		M.adjustOxyLoss(-20 * removed)
+		M.heal_organ_damage(20 * removed, 20 * removed)
 		M.adjustToxLoss(-10 * removed)
 
 /datum/reagent/clonexadone

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -32,7 +32,7 @@
 	name = "Cordrazine"
 	id = "cordrazine"
 	result = "cordrazine"
-	required_reagents = list("lithium" = 1, "inaprovaline" = 1, "nitrogen" = 1)
+	required_reagents = list("lithium" = 1, "synaptizine" = 1, "nitrogen" = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/dylovene
@@ -258,6 +258,13 @@
 	id = "cryoxadone"
 	result = "cryoxadone"
 	required_reagents = list("dexalin" = 1, "water" = 1, "oxygen" = 1)
+	result_amount = 3
+	
+/datum/chemical_reaction/pyroxadone
+	name = "Pyroxadone"
+	id = "pyroxadone"
+	result = "pyroxadone"
+	required_reagents = list("cryoxadone" = 1, "phosphorus" = 1, "sulfur" = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/clonexadone

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -73,3 +73,17 @@
 		user << "<span class='notice'>It is currently loaded.</span>"
 	else
 		user << "<span class='notice'>It is spent.</span>"
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine
+	name = "Cordrazine autoinjector"
+	desc = "This autoinjector contains a small amount of cordrazine, a chemical which rapidly combats paralysis and weakness in the patient. Use this to wake patients up after surgery."
+	icon_state = "autoinjectorc" //Sprite coming later today
+	item_state = "autoinjectorc" //s
+	amount_per_transfer_from_this = 5
+	volume = 5
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/cordrazine/New()
+	..()
+	reagents.add_reagent("cordrazine", 5)
+	update_icon()
+	return

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -105,14 +105,13 @@
 		..()
 		reagents.add_reagent("anti_toxin", 25)
 
-/obj/item/weapon/reagent_containers/pill/synaptezine
-	name = "Synaptezine pill"
-	desc = "Treats paralysis and weakness, along with other conditions associated with the mind."
+/obj/item/weapon/reagent_containers/pill/cordrazine
+	name = "Cordrazine pill"
+	desc = "Rapidly treats paralysis and weakness, while stimulating the mind and heart. Useful for waking people up."
 	icon_state = "pill8"
 	New()
 		..()
-		reagents.add_reagent("synaptezine", 2)
-		reagents.add_reagent("dylovene", 5)
+		reagents.add_reagent("cordrazine", 15)
 
 /obj/item/weapon/reagent_containers/pill/tox
 	name = "Toxins pill"


### PR DESCRIPTION
Cordrazine is necessary for the production of Chloromydride, which is why people can't make it at the moment. This pull corrects this.

Cordrazine: Rapidly combats paralysis and weakness, waking the target up. It metabolises five times faster than usual, so it is not a long-term solution, and won't help in fights. It is a precursor to Chloromydride.

Pyroxadone: This is an upgraded version of Cryoxadone which only works in very high temperatures, making it perfect for increasing your survivability in fire, or saving patients who were dragged out of the flames. Useless at other temperatures, though. [Needs review as to what temperature it comes into affect at and as to its effectiveness]

without this, Chloromydride is currently unmakeable, making the chemical completely useless.
