### PR TITLE
Orderable Protohumans (V.2)

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1515,6 +1515,6 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 
 /datum/supply_packs/proto
 	containertype = /obj/structure/largecrate/animal/proto
-	containername = "Protohuman test subject crate"
+	containername = "Protohuman subject crate"
 	group = "Science"
 	cost = 35

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1512,3 +1512,9 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 		/obj/item/device/kit/paint/gygax/recitence
 		)
 	name = "Random Gygax exosuit modkit"
+
+/datum/supply_packs/proto
+	containertype = /obj/structure/largecrate/animal/proto
+	containername = "Protohuman test subject crate"
+	group = "Science"
+	cost = 35

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -74,3 +74,7 @@
 	name = "chicken crate"
 	held_count = 5
 	held_type = /mob/living/simple_animal/chick
+
+/obj/structure/largecrate/animal/proto
+	name = "protohuman crate"
+	held_type = /mob/living/carbon/human


### PR DESCRIPTION
Makes Protohumans orderable for 35 points.
