### PR TITLE
Slime apocalypse fix

### DIFF
--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -408,6 +408,13 @@
 			adjustToxLoss(-10)
 	nutrition = max(nutrition, get_max_nutrition())
 
+/mob/living/carbon/slime/proc/apply_water(var/amount)
+	adjustToxLoss(15 + amount)
+	if(!client)
+		Target = null
+		++Discipline
+	return
+
 /mob/living/carbon/slime/cannot_use_vents()
 	if(Victim)
 		return "You cannot ventcrawl while feeding."


### PR DESCRIPTION
Slimes again are now able to be damaged through the application of water
via fire extinguishers.
