### PR TITLE
Loads 'a fixes 

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -108,6 +108,7 @@
 #include "code\controllers\Processes\mob.dm"
 #include "code\controllers\Processes\nanoui.dm"
 #include "code\controllers\Processes\obj.dm"
+#include "code\controllers\Processes\pipenet.dm"
 #include "code\controllers\Processes\Shuttle.dm"
 #include "code\controllers\Processes\sun.dm"
 #include "code\controllers\Processes\supply.dm"

--- a/code/controllers/Processes/machinery.dm
+++ b/code/controllers/Processes/machinery.dm
@@ -6,6 +6,7 @@
 
 /datum/controller/process/machinery/doWork()
 	internal_sort()
+	internal_process_pipenets()
 	internal_process_machinery()
 	internal_process_power()
 	internal_process_power_drain()

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -24,7 +24,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 
 /datum/emergency_shuttle_controller/proc/process()
 	if (wait_for_launch)
-		if (auto_recall && world.time >= auto_recall_time)
+		if (evac && auto_recall && world.time >= auto_recall_time)
 			recall()
 		if (world.time >= launch_time)	//time to launch the shuttle
 			stop_launch_countdown()

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -11,15 +11,14 @@ var/datum/antagonist/mercenary/mercs
 	leader_welcome_text = "You are the leader of the mercenary strikeforce; hail to the chief. Use :t to speak to your underlings."
 	welcome_text = "To speak on the strike team's private channel use :t."
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_HAS_NUKE | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
-
+	id_type = /obj/item/weapon/card/id/syndicate
+	antaghud_indicator = "hudoperative"
+	
 	hard_cap = 4
 	hard_cap_round = 8
 	initial_spawn_req = 4
 	initial_spawn_target = 6
 	
-	id_type = /obj/item/weapon/card/id/syndicate
-	antaghud_indicator = "hudoperative"
- 
 /datum/antagonist/mercenary/New()
 	..()
 	mercs = src
@@ -44,16 +43,15 @@ var/datum/antagonist/mercenary/mercs
 	if(player.backbag == 4) player.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(player), slot_back)
 	player.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(player.back), slot_in_backpack)
 	player.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/pill/cyanide(player), slot_in_backpack)
+
+	if (player.mind == leader)
+		var/obj/item/device/radio/uplink/U = new(player.loc)
+		U.hidden_uplink.uplink_owner = player.mind
+		U.hidden_uplink.uses = 40
+		player.put_in_hands(U)
+
 	player.update_icons()
 
 	create_id("Mercenary", player)
 	create_radio(SYND_FREQ, player)
 	return 1
-
-/datum/antagonist/mercenary/create_nuke()
-	..()
-	// Create the radio.
-	var/obj/effect/landmark/uplinkdevice = locate("landmark*Syndicate-Uplink")
-	if(uplinkdevice)
-		var/obj/item/device/radio/uplink/U = new(uplinkdevice.loc)
-		U.hidden_uplink.uses = 40

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -185,6 +185,8 @@ var/global/list/additional_antag_types = list()
 			return
 		var/datum/antagonist/antag = all_antag_types[choice]
 		if(antag)
+			if(!islist(ticker.mode.antag_templates))
+				ticker.mode.antag_templates = list()
 			ticker.mode.antag_templates |= antag
 			message_admins("Admin [key_name_admin(usr)] added [antag.role_text] template to game mode.")
 
@@ -512,6 +514,8 @@ var/global/list/additional_antag_types = list()
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
 		for(var/mob/player in player_list)
 			if(!player.client)
+				continue
+			if(istype(player, /mob/new_player))
 				continue
 			if(!role || (player.client.prefs.be_special & role))
 				log_debug("[player.key] had [antag_id] enabled, so we are drafting them.")

--- a/code/game/gamemodes/game_mode_latespawn.dm
+++ b/code/game/gamemodes/game_mode_latespawn.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/var/next_spawn = 0
 /datum/game_mode/var/min_autotraitor_delay = 4200  // Approx 7 minutes.
 /datum/game_mode/var/max_autotraitor_delay = 12000 // Approx 20 minutes.
+/datum/game_mode/var/process_count = 0
 
 /datum/game_mode/proc/get_usable_templates(var/list/supplied_templates)
 	var/list/usable_templates = list()
@@ -13,7 +14,11 @@
 ///process()
 ///Called by the gameticker
 /datum/game_mode/proc/process()
-	try_latespawn()
+	// Slow this down a bit so latejoiners have a chance of being antags.
+	process_count++
+	if(process_count >= 10)
+		process_count = 0
+		try_latespawn()
 /datum/game_mode/proc/latespawn(var/mob/living/carbon/human/character)
 	if(!character.mind)
 		return

--- a/code/game/gamemodes/game_mode_latespawn.dm
+++ b/code/game/gamemodes/game_mode_latespawn.dm
@@ -1,7 +1,6 @@
 /datum/game_mode/var/next_spawn = 0
 /datum/game_mode/var/min_autotraitor_delay = 4200  // Approx 7 minutes.
 /datum/game_mode/var/max_autotraitor_delay = 12000 // Approx 20 minutes.
-/datum/game_mode/var/process_count = 0
 
 /datum/game_mode/proc/get_usable_templates(var/list/supplied_templates)
 	var/list/usable_templates = list()
@@ -14,11 +13,8 @@
 ///process()
 ///Called by the gameticker
 /datum/game_mode/proc/process()
-	// Slow this down a bit so latejoiners have a chance of being antags.
-	process_count++
-	if(process_count >= 10)
-		process_count = 0
-		try_latespawn()
+	try_latespawn()
+
 /datum/game_mode/proc/latespawn(var/mob/living/carbon/human/character)
 	if(!character.mind)
 		return
@@ -33,7 +29,6 @@
 	if(world.time < next_spawn)
 		return
 
-		
 	message_admins("AUTO[uppertext(name)]: Attempting spawn.")
 
 	var/list/usable_templates
@@ -45,7 +40,7 @@
 		message_admins("AUTO[uppertext(name)]: Failed to find configured mode spawn templates, please disable auto-antagonists until one is added.")
 		round_autoantag = 0
 		return
-		
+
 	while(usable_templates.len)
 		var/datum/antagonist/spawn_antag = pick(usable_templates)
 		usable_templates -= spawn_antag

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -8,10 +8,18 @@
 	w_class = 2.0
 	var/obj/item/weapon/implant/imp = null
 
+/obj/item/weapon/implanter/attack_self(var/mob/user)
+	if(!imp)
+		return ..()
+	imp.loc = get_turf(src)
+	user.put_in_hands(imp)
+	user << "<span class='notice'>You remove \the [imp] from \the [src].</span>"
+	name = "implanter"
+	imp = null
+	update()
+	return
+
 /obj/item/weapon/implanter/proc/update()
-
-
-/obj/item/weapon/implanter/update()
 	if (src.imp)
 		src.icon_state = "implanter1"
 	else

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -751,7 +751,8 @@ proc/admin_notice(var/message, var/rights)
 	if(message)
 		if(!check_rights(R_SERVER,0))
 			message = sanitize(message, 500, extra = 0)
-		world << "\blue <b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b>\n \t [message]"
+		message = replacetext(message, "\n", "<br>") // required since we're putting it in a <p> tag
+		world << "<span class=notice><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b><p style='text-indent: 50px'>[message]</p></span>"
 		log_admin("Announce: [key_name(usr)] : [message]")
 	feedback_add_details("admin_verb","A") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -780,7 +780,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(confirm != "Yes") return
 
 	var/choice
-	if(ticker.mode.name == "revolution" || ticker.mode.name == "confliction")
+	if(ticker.mode.auto_recall_shuttle)
 		choice = input("The shuttle will just return if you call it. Call anyway?") in list("Confirm", "Cancel")
 		if(choice == "Confirm")
 			emergency_shuttle.auto_recall = 1	//enable auto-recall

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -101,7 +101,7 @@
 				if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS))
 					if(seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) < 0.05)
 						dat += "<td>Low</td>"
-					else if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) > 0.2)
+					else if(seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) > 0.2)
 						dat += "<td>High</td>"
 					else
 						dat += "<td>Norm</td>"

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -30,7 +30,7 @@
 	poison_type = "oxygen"
 	siemens_coefficient = 0.2
 
-	flags = CAN_JOIN | IS_WHITELISTED | NO_SCAN | HAS_EYE_COLOR
+	flags = IS_RESTRICTED | IS_WHITELISTED | NO_SCAN | HAS_EYE_COLOR
 
 	blood_color = "#2299FC"
 	flesh_color = "#808D11"

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -93,6 +93,10 @@
 	return 0
 
 /obj/nano_module/appearance_changer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+
+	if(!owner || !owner.species)
+		return
+
 	generate_data(check_whitelist, whitelist, blacklist)
 	var/data[0]
 


### PR DESCRIPTION
-Auto-recall-shuttle now works properly. 
-Mercenary will properly report purchased items.
-Admin server announcement formatting improved.
-Botany plant storage nutrient checks fixed.
-Runtime error in character creation fixed.
-You can now remove implants from the implantipad.
-Atmos fix, delete pipenet.dm after merging.
-Vox are no longer a playable species. 
