### PR TITLE
Fixes #175 - Cleartox overlay removal

### DIFF
--- a/code/modules/admin/verbs/cleartoxin.dm
+++ b/code/modules/admin/verbs/cleartoxin.dm
@@ -23,5 +23,6 @@
 		for(var/turf/T in location.zone.contents)
 			for(var/obj/fire/F in T.contents)
 				del(F)
+			T.overlays = null
 		for(var/obj/fire/FF in world)
 			del(FF)


### PR DESCRIPTION
Clear Toxin should now remove all phoron overlays in the zone. Fixes #175 
